### PR TITLE
Shared-memory parallel execution of BHMie

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,6 +16,10 @@ bhmie:		$(OBJECTS)
 		mkdir -p bin/
 		$(FC) $(OBJECTS) -o bin/bhmie
 
+parallel:	$(OBJECTS)
+		mkdir -p bin/
+		$(FC) -fopenmp $(OBJECTS) -o bin/bhmie 
+
 install:	bin/bhmie
 		mkdir -p @prefix@/bin/
 		cp bin/bhmie @prefix@/bin/

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,8 @@ elif test "$FC" == gfortran
 then
 	AC_SUBST(posix_module,posix_empty)
 	AC_SUBST(extra,'-Jsrc/modules -Isrc/modules -ffree-line-length-none')
+	AC_SUBST(omp_flags,'-fopenmp')
 fi
+
 
 AC_OUTPUT(Makefile)

--- a/src/bhmie_caller.f90
+++ b/src/bhmie_caller.f90
@@ -192,22 +192,22 @@ contains
                 s34_i = aimag(s2_i * conjg(s1_i))
 
                 ! Add to running total
-                !$omp critical
+                !$omp critical (inner_loop)
                 s11(iw, :) = s11(iw, :) + s11_i * weight_number
                 s12(iw, :) = s12(iw, :) + s12_i * weight_number
                 s33(iw, :) = s33(iw, :) + s33_i * weight_number
                 s34(iw, :) = s34(iw, :) + s34_i * weight_number
-                !$omp end critical
+                !$omp end critical (inner_loop)
 
              end do
 
              ! Add values for single size to the totals
-             !$omp critical
+             !$omp critical (middle_loop)
              cext = cext + cext_i * weight_number
              csca = csca + csca_i * weight_number
              cback = cback + cback_i * weight_number
              gsca = gsca + gsca_i * csca_i * weight_number
-             !$omp end critical
+             !$omp end critical (middle_loop)
 
           end if
 

--- a/src/bhmie_caller.f90
+++ b/src/bhmie_caller.f90
@@ -15,7 +15,7 @@ module bhmie_wrapper
 contains
 
   subroutine compute_dust_properties(prefix, output_format, abundance_mass, m, d, &
-       & density, gas_to_dust, amin, amax, na, wavelengths, n_angles, n_small_angles)
+       & density, gas_to_dust, amin, amax, na, wavelengths, n_angles, n_small_angles,n_threads)
 
     implicit none
 
@@ -24,6 +24,8 @@ contains
 
     integer,intent(in) :: output_format
     ! the file format for outputting
+
+    integer,intent(in) :: n_threads
 
     type(material),intent(in) :: m(:)
     ! list of materials
@@ -145,7 +147,7 @@ contains
 
     call print_progress_bar(1,na)
 
-    !$omp parallel do default(firstprivate) shared(cext,csca,cback,gsca,kappa_ext,s11,s12,s33,s34)
+    !$omp parallel do default(firstprivate) shared(cext,csca,cback,gsca,kappa_ext,s11,s12,s33,s34) num_threads(n_threads)
     do ia=1,na
 
        call delete_progress_bar(ia,na)

--- a/src/bhmie_caller.f90
+++ b/src/bhmie_caller.f90
@@ -147,6 +147,8 @@ contains
 
     call print_progress_bar(1,na)
 
+    !$ omp_set_num_threads(n_threads)
+
     !$omp parallel do default(firstprivate) shared(cext,csca,cback,gsca,kappa_ext,s11,s12,s33,s34) num_threads(n_threads)
     do ia=1,na
        !$ if ia .eq. 1 print*,"Number of threads in use = ", omp_get_num_threads()

--- a/src/bhmie_caller.f90
+++ b/src/bhmie_caller.f90
@@ -147,11 +147,11 @@ contains
 
     call print_progress_bar(1,na)
 
-    !$ omp_set_num_threads(n_threads)
+    !$call omp_set_num_threads(n_threads)
 
     !$omp parallel do default(firstprivate) shared(cext,csca,cback,gsca,kappa_ext,s11,s12,s33,s34) num_threads(n_threads)
     do ia=1,na
-       !$ if ia .eq. 1 print*,"Number of threads in use = ", omp_get_num_threads()
+       !$if ia .eq. 1 print*,"Number of threads in use = ", omp_get_num_threads()
 
        call delete_progress_bar(ia,na)
        call print_progress_bar(ia,na)

--- a/src/bhmie_caller.f90
+++ b/src/bhmie_caller.f90
@@ -190,26 +190,22 @@ contains
                 s34_i = aimag(s2_i * conjg(s1_i))
 
                 ! Add to running total
-                !$omp atomic
+                !$omp critical
                 s11(iw, :) = s11(iw, :) + s11_i * weight_number
-                !$omp atomic
                 s12(iw, :) = s12(iw, :) + s12_i * weight_number
-                !$omp atomic
                 s33(iw, :) = s33(iw, :) + s33_i * weight_number
-                !$omp atomic
                 s34(iw, :) = s34(iw, :) + s34_i * weight_number
+                !$omp end critical
 
              end do
 
              ! Add values for single size to the totals
-             !$omp atomic
+             !$omp critical
              cext = cext + cext_i * weight_number
-             !$omp atomic
              csca = csca + csca_i * weight_number
-             !$omp atomic
              cback = cback + cback_i * weight_number
-             !$omp atomic
              gsca = gsca + gsca_i * csca_i * weight_number
+             !$omp end critical
 
           end if
 

--- a/src/bhmie_caller.f90
+++ b/src/bhmie_caller.f90
@@ -149,6 +149,7 @@ contains
 
     !$omp parallel do default(firstprivate) shared(cext,csca,cback,gsca,kappa_ext,s11,s12,s33,s34) num_threads(n_threads)
     do ia=1,na
+       !$ if ia .eq. 1 print*,"Number of threads in use = ", omp_get_num_threads()
 
        call delete_progress_bar(ia,na)
        call print_progress_bar(ia,na)

--- a/src/main.f90
+++ b/src/main.f90
@@ -43,6 +43,9 @@ program main
   integer :: n_wav
   real(dp) :: wav_min, wav_max
 
+
+  integer :: n_threads=1 !needed for omp parallel version
+
   ! retrieve parameter file from command-line
   call get_command_argument(1, input_file)
   if(trim(input_file)=='') stop "Usage: bhmie input_file"
@@ -61,6 +64,7 @@ program main
   read(32,*) n_components
   read(32,*) gas_to_dust
   read(32,*) wav_min, wav_max, n_wav
+  !$ read(32,*) n_threads
 
   allocate(wavelengths(n_wav))
   call logspace(wav_min, wav_max, wavelengths)
@@ -86,6 +90,6 @@ program main
   abundance_mass = abundance_mass / sum(abundance_mass)
 
   call compute_dust_properties(prefix,output_format,abundance_mass,m,d,density, &
-       & gas_to_dust,amin,amax,na,wavelengths,n_angles,n_small_angles)
+       & gas_to_dust,amin,amax,na,wavelengths,n_angles,n_small_angles,n_threads)
 
 end program main

--- a/src/main.f90
+++ b/src/main.f90
@@ -66,6 +66,8 @@ program main
   read(32,*) wav_min, wav_max, n_wav
   !$ read(32,*) n_threads
 
+  !$ print*,"Running in parallel with ",n_threads," threads"
+
   allocate(wavelengths(n_wav))
   call logspace(wav_min, wav_max, wavelengths)
 


### PR DESCRIPTION
Mie calculus is pretty slow, and sometimes it can be useful to execute it in parallel. I have added OpenMP directives in appropriate places in the code - in a trade-off between efficiency and expected number of times it is used, the code parallelises over grain sizes.